### PR TITLE
CMake: Add various fixes to CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,8 +86,10 @@ CUSTOM_VAPIS
 OPTIONS
   #  --enable-experimental
     --target-glib=2.32 # Remember to keep this updated.
-    --thread
-   # -X -rdynamic
+  #  The --thread option is now deprecated.
+  #  Should be ignored, but actually it leads to a build failure.
+  #  --thread
+  #  -X -rdynamic
   #  -g
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,8 @@ add_dependencies(com.github.parnold-x.nasc
 target_link_libraries(com.github.parnold-x.nasc
   ${QALCULATE_LIB_PATH}
   ${DEPS_LIBRARIES}
-  qalculatenasc)
+  qalculatenasc
+  -lcln)
 
 install (TARGETS com.github.parnold-x.nasc RUNTIME DESTINATION bin)
 

--- a/libqalculatenasc/CMakeLists.txt
+++ b/libqalculatenasc/CMakeLists.txt
@@ -1,7 +1,7 @@
 pkg_check_modules(QALC REQUIRED libqalculate)
 link_directories(${QALC_LIBRARY_DIRS})
 include_directories(${QALC_INCLUDE_DIRS})
- add_library(qalculatenasc SHARED
+ add_library(qalculatenasc STATIC
   QalculateNasc.cc)
-target_link_libraries(qalculatenasc ${QALC_LIBRARIES})
+target_link_libraries(qalculatenasc ${QALC_LIBRARIES} -lcln)
 


### PR DESCRIPTION
## CMake: Fix linking

Fixes #97 and #103

Build app with static library.

See also:
https://build.opensuse.org/package/view_file/openSUSE:Factory/nasc/nasc-0.5.0-link.patch?expand=1

## CMake: Remove --thread option for Vala Compiler

The `--thread` option is now deprecated.
Should be ignored, but actually it leads to a build failure.

See also:
https://github.com/GNOME/vala/blob/f7c386eae4a1ab15eb4a21dce540e6298d93436c/compiler/valacompiler.vala#L131